### PR TITLE
Wash 0.6.0 upgrade fixes

### DIFF
--- a/control-interface.smithy
+++ b/control-interface.smithy
@@ -266,20 +266,14 @@ list HostList {
     member: Host,
 }
 
-
 /// response to get_claims
 structure GetClaimsResponse {
     @required
     claims: ClaimsList
 }
 
-structure Claims {
-    @required
-    values: ClaimsMap,
-}
-
 list ClaimsList {
-    member: Claims,
+    member: ClaimsMap,
 }
 
 map ClaimsMap {

--- a/control-interface.smithy
+++ b/control-interface.smithy
@@ -246,6 +246,11 @@ structure UpdateActorAck {
     accepted: Boolean,
 }
 
+structure CacheAck {
+    @required
+    accepted: Boolean,
+}
+
 
 structure LinkDefinitionList {
     @required

--- a/control-interface.smithy
+++ b/control-interface.smithy
@@ -147,19 +147,6 @@ structure StartActorCommand {
     hostId: String,
 }
 
-structure StartActorAck {
-    @required
-    @serialization(name: "actor_ref")
-    actorRef: String,
-
-    @required
-    @serialization(name: "host_id")
-    hostId: String,
-
-    /// optional failure message
-    failure: String,
-}
-
 structure StartProviderCommand {
     @required
     @serialization(name: "host_id")
@@ -174,19 +161,6 @@ structure StartProviderCommand {
     linkName: String,
 }
 
-structure StartProviderAck {
-    @required
-    @serialization(name: "host_id")
-    hostId: String,
-
-    @required
-    @serialization(name: "provider_ref")
-    providerRef: String,
-
-    /// optional failure message
-    failure: String,
-}
-
 structure StopActorCommand {
     @required
     @serialization(name: "host_id")
@@ -198,10 +172,6 @@ structure StopActorCommand {
 
     /// optional count
     count: U16,
-}
-
-structure StopActorAck {
-    failure: String,
 }
 
 structure StopProviderCommand {
@@ -222,11 +192,6 @@ structure StopProviderCommand {
     contractId: String,
 }
 
-structure StopProviderAck {
-    failure: String,
-}
-
-
 structure UpdateActorCommand {
     @required
     @serialization(name: "host_id")
@@ -241,16 +206,13 @@ structure UpdateActorCommand {
     newActorRef: String,
 }
 
-structure UpdateActorAck {
+/// Standard response for control interface operations
+structure CtlOperationAck {
     @required
     accepted: Boolean,
-}
-
-structure CacheAck {
     @required
-    accepted: Boolean,
+    error: String
 }
-
 
 structure LinkDefinitionList {
     @required

--- a/rust/src/broker.rs
+++ b/rust/src/broker.rs
@@ -62,6 +62,6 @@ pub mod queries {
     }
 
     pub fn hosts(nsprefix: &Option<String>) -> String {
-        format!("{}.get.hosts", prefix(nsprefix))
+        format!("{}.ping.hosts", prefix(nsprefix))
     }
 }

--- a/rust/src/broker.rs
+++ b/rust/src/broker.rs
@@ -18,7 +18,7 @@ pub fn actor_auction_subject(nsprefix: &Option<String>) -> String {
 }
 
 pub fn advertise_link(ns_prefix: &Option<String>) -> String {
-    format!("{}.linkdef.put", prefix(ns_prefix))
+    format!("{}.linkdefs.put", prefix(ns_prefix))
 }
 
 pub mod commands {

--- a/rust/src/broker.rs
+++ b/rust/src/broker.rs
@@ -6,7 +6,10 @@ fn prefix(nsprefix: &Option<String>) -> String {
 }
 
 pub fn control_event(nsprefix: &Option<String>) -> String {
-    format!("{}.events", prefix(nsprefix))
+    format!(
+        "wasmbus.evt.{}",
+        nsprefix.as_ref().unwrap_or(&"default".to_string())
+    )
 }
 
 pub fn provider_auction_subject(nsprefix: &Option<String>) -> String {

--- a/rust/src/control.rs
+++ b/rust/src/control.rs
@@ -45,17 +45,20 @@ pub struct ActorDescription {
 
 pub type ActorDescriptions = Vec<ActorDescription>;
 
-#[derive(Default, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct CacheAck {
-    #[serde(default)]
-    pub accepted: bool,
-}
-
 pub type ClaimsList = Vec<ClaimsMap>;
 
 pub type ClaimsMap = std::collections::HashMap<String, String>;
 
 pub type ConstraintMap = std::collections::HashMap<String, String>;
+
+/// Standard response for control interface operations
+#[derive(Default, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct CtlOperationAck {
+    #[serde(default)]
+    pub accepted: bool,
+    #[serde(default)]
+    pub error: String,
+}
 
 /// response to get_claims
 #[derive(Default, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -124,33 +127,11 @@ pub struct ProviderDescription {
 pub type ProviderDescriptions = Vec<ProviderDescription>;
 
 #[derive(Default, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct StartActorAck {
-    #[serde(default)]
-    pub actor_ref: String,
-    /// optional failure message
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub failure: Option<String>,
-    #[serde(default)]
-    pub host_id: String,
-}
-
-#[derive(Default, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct StartActorCommand {
     #[serde(default)]
     pub actor_ref: String,
     #[serde(default)]
     pub host_id: String,
-}
-
-#[derive(Default, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct StartProviderAck {
-    /// optional failure message
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub failure: Option<String>,
-    #[serde(default)]
-    pub host_id: String,
-    #[serde(default)]
-    pub provider_ref: String,
 }
 
 #[derive(Default, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -161,12 +142,6 @@ pub struct StartProviderCommand {
     pub link_name: String,
     #[serde(default)]
     pub provider_ref: String,
-}
-
-#[derive(Default, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct StopActorAck {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub failure: Option<String>,
 }
 
 #[derive(Default, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -181,12 +156,6 @@ pub struct StopActorCommand {
 }
 
 #[derive(Default, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct StopProviderAck {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub failure: Option<String>,
-}
-
-#[derive(Default, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct StopProviderCommand {
     #[serde(default)]
     pub contract_id: String,
@@ -196,12 +165,6 @@ pub struct StopProviderCommand {
     pub link_name: String,
     #[serde(default)]
     pub provider_ref: String,
-}
-
-#[derive(Default, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct UpdateActorAck {
-    #[serde(default)]
-    pub accepted: bool,
 }
 
 #[derive(Default, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/rust/src/control.rs
+++ b/rust/src/control.rs
@@ -45,12 +45,7 @@ pub struct ActorDescription {
 
 pub type ActorDescriptions = Vec<ActorDescription>;
 
-#[derive(Default, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct Claims {
-    pub values: ClaimsMap,
-}
-
-pub type ClaimsList = Vec<Claims>;
+pub type ClaimsList = Vec<ClaimsMap>;
 
 pub type ClaimsMap = std::collections::HashMap<String, String>;
 

--- a/rust/src/control.rs
+++ b/rust/src/control.rs
@@ -45,6 +45,12 @@ pub struct ActorDescription {
 
 pub type ActorDescriptions = Vec<ActorDescription>;
 
+#[derive(Default, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct CacheAck {
+    #[serde(default)]
+    pub accepted: bool,
+}
+
 pub type ClaimsList = Vec<ClaimsMap>;
 
 pub type ClaimsMap = std::collections::HashMap<String, String>;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -132,7 +132,7 @@ impl Client {
     /// wasmCloud hosts will acknowledge the start actor command prior to fetching the actor's OCI bytes. If a client needs
     /// deterministic results as to whether the actor completed its startup process, the client will have to monitor
     /// the appropriate event in the control event stream
-    pub async fn start_actor(&self, host_id: &str, actor_ref: &str) -> Result<StartActorAck> {
+    pub async fn start_actor(&self, host_id: &str, actor_ref: &str) -> Result<CtlOperationAck> {
         let subject = broker::commands::start_actor(&self.nsprefix, host_id);
         trace!("start_actor:request {}", &subject);
         let bytes = json_serialize(StartActorCommand {
@@ -145,7 +145,7 @@ impl Client {
             .await
         {
             Ok(msg) => {
-                let ack: StartActorAck = json_deserialize(&msg.data)?;
+                let ack: CtlOperationAck = json_deserialize(&msg.data)?;
                 Ok(ack)
             }
             Err(e) => Err(format!("Did not receive start actor acknowledgement: {}", e).into()),
@@ -162,7 +162,7 @@ impl Client {
         contract_id: &str,
         link_name: &str,
         values: HashMap<String, String>,
-    ) -> Result<CacheAck> {
+    ) -> Result<CtlOperationAck> {
         let subject = broker::advertise_link(&self.nsprefix);
         trace!("advertise_link:publish {}", &subject);
         let ld = LinkDefinition {
@@ -179,7 +179,7 @@ impl Client {
             .await
         {
             Ok(msg) => {
-                let ack: CacheAck = json_deserialize(&msg.data)?;
+                let ack: CtlOperationAck = json_deserialize(&msg.data)?;
                 Ok(ack)
             }
             Err(e) => Err(format!("Did not receive advertise link acknowledgement: {}", e).into()),
@@ -227,7 +227,7 @@ impl Client {
         host_id: &str,
         existing_actor_id: &str,
         new_actor_ref: &str,
-    ) -> Result<UpdateActorAck> {
+    ) -> Result<CtlOperationAck> {
         let subject = broker::commands::update_actor(&self.nsprefix, host_id);
         trace!("update_actor:request {}", &subject);
         let bytes = json_serialize(UpdateActorCommand {
@@ -241,7 +241,7 @@ impl Client {
             .await
         {
             Ok(msg) => {
-                let ack: UpdateActorAck = json_deserialize(&msg.data)?;
+                let ack: CtlOperationAck = json_deserialize(&msg.data)?;
                 Ok(ack)
             }
             Err(e) => Err(format!("Did not receive update actor acknowledgement: {}", e).into()),
@@ -259,7 +259,7 @@ impl Client {
         host_id: &str,
         provider_ref: &str,
         link_name: Option<String>,
-    ) -> Result<StartProviderAck> {
+    ) -> Result<CtlOperationAck> {
         let subject = broker::commands::start_provider(&self.nsprefix, host_id);
         trace!("start_provider:request {}", &subject);
         let bytes = json_serialize(StartProviderCommand {
@@ -273,7 +273,7 @@ impl Client {
             .await
         {
             Ok(msg) => {
-                let ack: StartProviderAck = json_deserialize(&msg.data)?;
+                let ack: CtlOperationAck = json_deserialize(&msg.data)?;
                 Ok(ack)
             }
             Err(e) => Err(format!("Did not receive start provider acknowledgement: {}", e).into()),
@@ -290,7 +290,7 @@ impl Client {
         provider_ref: &str,
         link_name: &str,
         contract_id: &str,
-    ) -> Result<StopProviderAck> {
+    ) -> Result<CtlOperationAck> {
         let subject = broker::commands::stop_provider(&self.nsprefix, host_id);
         trace!("stop_provider:request {}", &subject);
         let bytes = json_serialize(StopProviderCommand {
@@ -305,7 +305,7 @@ impl Client {
             .await
         {
             Ok(msg) => {
-                let ack: StopProviderAck = json_deserialize(&msg.data)?;
+                let ack: CtlOperationAck = json_deserialize(&msg.data)?;
                 Ok(ack)
             }
             Err(e) => Err(format!("Did not receive stop provider acknowledgement: {}", e).into()),
@@ -321,7 +321,7 @@ impl Client {
         host_id: &str,
         actor_ref: &str,
         count: u16,
-    ) -> Result<StopActorAck> {
+    ) -> Result<CtlOperationAck> {
         let subject = broker::commands::stop_actor(&self.nsprefix, host_id);
         trace!("stop_actor:request {}", &subject);
         let bytes = json_serialize(StopActorCommand {
@@ -335,7 +335,7 @@ impl Client {
             .await
         {
             Ok(msg) => {
-                let ack: StopActorAck = json_deserialize(&msg.data)?;
+                let ack: CtlOperationAck = json_deserialize(&msg.data)?;
                 Ok(ack)
             }
             Err(e) => Err(format!("Did not receive stop actor acknowledgement: {}", e).into()),

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -12,20 +12,15 @@ use nats::asynk::Connection;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, time::Duration};
 use sub_stream::SubscriptionStream;
-//use wascap::prelude::KeyPair;
-// use and re-export LinkDefinition
 pub use wasmbus_rpc::{core::LinkDefinition, RpcClient};
 
 type Result<T> = ::std::result::Result<T, Box<dyn ::std::error::Error + Send + Sync>>;
-
-// const URL_SCHEME: &str = "wasmbus";
 
 /// Lattice control interface client
 pub struct Client {
     nc: nats::asynk::Connection,
     nsprefix: Option<String>,
     timeout: Duration,
-    //key: KeyPair,
 }
 
 impl Client {
@@ -35,7 +30,6 @@ impl Client {
             nc,
             nsprefix,
             timeout,
-            //key: KeyPair::new_user(),
         }
     }
 
@@ -48,6 +42,41 @@ impl Client {
             .collect(timeout, "get hosts")
             .await;
         Ok(hosts)
+    }
+
+    /// Retrieves the contents of a running host
+    pub async fn get_host_inventory(&self, host_id: &str) -> Result<HostInventory> {
+        let subject = broker::queries::host_inventory(&self.nsprefix, host_id);
+        trace!("get_host_inventory:request {}", &subject);
+        match self
+            .nc
+            .request_timeout(&subject, vec![], self.timeout)
+            .await
+        {
+            Ok(msg) => {
+                let hi: HostInventory = json_deserialize(&msg.data)?;
+                Ok(hi)
+            }
+            Err(e) => Err(format!("Did not receive host inventory from target host: {}", e).into()),
+        }
+    }
+
+    /// Retrieves the full set of all cached claims in the lattice by getting a response from the first
+    /// host that answers this query
+    pub async fn get_claims(&self) -> Result<GetClaimsResponse> {
+        let subject = broker::queries::claims(&self.nsprefix);
+        trace!("get_claims:request {}", &subject);
+        match self
+            .nc
+            .request_timeout(&subject, vec![], self.timeout)
+            .await
+        {
+            Ok(msg) => {
+                let list: GetClaimsResponse = json_deserialize(&msg.data)?;
+                Ok(list)
+            }
+            Err(e) => Err(format!("Did not receive claims from lattice: {}", e).into()),
+        }
     }
 
     /// Performs an actor auction within the lattice, publishing a set of constraints and the metadata for the actor
@@ -97,24 +126,6 @@ impl Client {
             .await;
         Ok(providers)
     }
-
-    /// Retrieves the contents of a running host
-    pub async fn get_host_inventory(&self, host_id: &str) -> Result<HostInventory> {
-        let subject = broker::queries::host_inventory(&self.nsprefix, host_id);
-        trace!("get_host_inventory:request {}", &subject);
-        match self
-            .nc
-            .request_timeout(&subject, vec![], self.timeout)
-            .await
-        {
-            Ok(msg) => {
-                let hi: HostInventory = json_deserialize(&msg.data)?;
-                Ok(hi)
-            }
-            Err(e) => Err(format!("Did not receive host inventory from target host: {}", e).into()),
-        }
-    }
-
     /// Sends a request to the given host to start a given actor by its OCI reference. This returns an acknowledgement
     /// of _receipt_ of the command, not a confirmation that the actor started. An acknowledgement will either indicate
     /// some form of validation failure, or, if no failure occurs, the receipt of the command. To avoid blocking consumers,
@@ -320,24 +331,6 @@ impl Client {
                 Ok(ack)
             }
             Err(e) => Err(format!("Did not receive stop actor acknowledgement: {}", e).into()),
-        }
-    }
-
-    /// Retrieves the full set of all cached claims in the lattice by getting a response from the first
-    /// host that answers this query
-    pub async fn get_claims(&self) -> Result<GetClaimsResponse> {
-        let subject = broker::queries::claims(&self.nsprefix);
-        trace!("get_claims:request {}", &subject);
-        match self
-            .nc
-            .request_timeout(&subject, vec![], self.timeout)
-            .await
-        {
-            Ok(msg) => {
-                let list: GetClaimsResponse = json_deserialize(&msg.data)?;
-                Ok(list)
-            }
-            Err(e) => Err(format!("Did not receive claims from lattice: {}", e).into()),
         }
     }
 


### PR DESCRIPTION
Included a few modifications to the smithy interface to match types in the OTP runtime, and changed topics where applicable.

The `CacheAck` structure is used as a response to a few cache operations so I figured it would be worth creating a type for it. It's the same as UpdateActorAck at the moment as well, so let me know if you think we should consolidate these.