### PR TITLE
Added build and release actions

### DIFF
--- a/.github/workflows/wasmcloud-control-interface.yml
+++ b/.github/workflows/wasmcloud-control-interface.yml
@@ -1,0 +1,39 @@
+name: WASMCLOUD-CONTROL-INTERFACE
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+    - "rust/wasmcloud-control-interface/**"
+  pull_request:
+    branches: [ main ]
+    paths:
+    - "rust/wasmcloud-control-interface/**"
+
+env:
+  CARGO_TERM_COLOR: always
+  working-directory: ./rust/wasmcloud-control-interface
+
+jobs:
+  cargo_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+      working-directory: ${{env.working-directory}}
+    - name: Run tests
+      run: cargo test --verbose
+      working-directory: ${{env.working-directory}}
+    - name: Check fmt
+      run: cargo fmt -- --check
+      working-directory: ${{env.working-directory}}
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup component add clippy
+      - name: Run cargo clippy
+        run: cargo clippy --all-features
+        working-directory: ${{env.working-directory}}

--- a/.github/workflows/wasmcloud-control-interface.yml
+++ b/.github/workflows/wasmcloud-control-interface.yml
@@ -4,15 +4,15 @@ on:
   push:
     branches: [ main ]
     paths:
-    - "rust/wasmcloud-control-interface/**"
+    - "rust/**"
   pull_request:
     branches: [ main ]
     paths:
-    - "rust/wasmcloud-control-interface/**"
+    - "rust/**"
 
 env:
   CARGO_TERM_COLOR: always
-  working-directory: ./rust/wasmcloud-control-interface
+  working-directory: ./rust
 
 jobs:
   cargo_check:

--- a/.github/workflows/wasmcloud-control-interface_release.yml
+++ b/.github/workflows/wasmcloud-control-interface_release.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  working-directory: ./rust/wasmcloud-control-interface
+  working-directory: ./rust
 
 jobs:
   cargo_check:

--- a/.github/workflows/wasmcloud-control-interface_release.yml
+++ b/.github/workflows/wasmcloud-control-interface_release.yml
@@ -1,0 +1,63 @@
+name: WASMCLOUD-CONTROL-INTERFACE_RELEASE
+
+on:
+  push:
+    tags:
+    - 'wasmcloud-control-interface-v*'
+
+env:
+  CARGO_TERM_COLOR: always
+  working-directory: ./rust/wasmcloud-control-interface
+
+jobs:
+  cargo_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+      working-directory: ${{ env.working-directory }}
+    - name: Run tests
+      run: cargo test --verbose
+      working-directory: ${{ env.working-directory }}
+    - name: Check fmt
+      run: cargo fmt -- --check
+      working-directory: ${{ env.working-directory }}
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup component add clippy
+      - name: Run cargo clippy
+        run: cargo clippy --all-features
+        working-directory: ${{ env.working-directory }}
+
+  github_release:
+    needs: [cargo_check, clippy_check]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: true
+
+  crates_release:
+    needs: github_release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Cargo login
+        env:
+          CRATES_TOKEN: ${{ secrets.CRATES_PUBLISH_TOKEN }}
+        run: cargo login ${{ env.CRATES_TOKEN }}
+      - name: Cargo publish
+        run: cargo publish --no-verify
+        working-directory: ${{ env.working-directory }}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -186,33 +186,30 @@ impl Client {
         }
     }
 
-    /**
-     Not currently supported
+    //  Not currently supported
+    //     /// Publishes a request to remove a link definition to the lattice. All hosts in the lattice will
+    //     /// receive this message and, if the appropriate capability provider is in that host, it will have
+    //     /// the "remove actor" operation sent to it. The link definition will also be removed from the lattice
+    //     /// cache. No confirmation or acknowledgement is available for this operation, you will need to monitor events
+    //     /// and/or query the lattice to confirm that the link has been removed.
+    //     pub async fn remove_link(
+    //         &self,
+    //         actor_id: &str,
+    //         contract_id: &str,
+    //         link_name: &str,
+    //     ) -> Result<()> {
+    //         let subject = broker::remove_link(&self.nsprefix);
+    //         let ld = LinkDefinition {
+    //             actor_id: actor_id.to_string(),
+    //             contract_id: contract_id.to_string(),
+    //             link_name: link_name.to_string(),
+    //             ..Default::default()
+    //         };
+    //         let bytes = crate::json_serialize(&ld)?;
+    //         self.nc.publish(&subject, &bytes).await?;
 
-        /// Publishes a request to remove a link definition to the lattice. All hosts in the lattice will
-        /// receive this message and, if the appropriate capability provider is in that host, it will have
-        /// the "remove actor" operation sent to it. The link definition will also be removed from the lattice
-        /// cache. No confirmation or acknowledgement is available for this operation, you will need to monitor events
-        /// and/or query the lattice to confirm that the link has been removed.
-        pub async fn remove_link(
-            &self,
-            actor_id: &str,
-            contract_id: &str,
-            link_name: &str,
-        ) -> Result<()> {
-            let subject = broker::remove_link(&self.nsprefix);
-            let ld = LinkDefinition {
-                actor_id: actor_id.to_string(),
-                contract_id: contract_id.to_string(),
-                link_name: link_name.to_string(),
-                ..Default::default()
-            };
-            let bytes = crate::json_serialize(&ld)?;
-            self.nc.publish(&subject, &bytes).await?;
-
-            Ok(())
-        }
-    **/
+    //         Ok(())
+    //     }
 
     /// Issue a command to a host instructing that it replace an existing actor (indicated by its
     /// public key) with a new actor indicated by an OCI image reference. The host will acknowledge

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -418,7 +418,6 @@ impl Client {
     }
 }
 
-//
 // [ss]: renamed to json_serialize and json_deserialize to avoid confusion
 //   with msgpack serialize and deserialize, used for rpc messages.
 //


### PR DESCRIPTION
I'd like to be able to publish release candidate versions of this crate so that we can test other programs like `wash`. This only required changing the `working-directory` environment variable from the main `wasmCloud` repository action

Signed-off-by: Brooks Townsend <brooksmtownsend@gmail.com>